### PR TITLE
7.5 fix

### DIFF
--- a/controls/overlay.rb
+++ b/controls/overlay.rb
@@ -223,23 +223,6 @@ include_controls 'oracle-mysql-ee-5.7-cis-baseline' do
     end
   end
   
-  control '7.5' do
-    tag "check": "Execute the following SQL query to determine if any users have a blank password:
-        SELECT user,host 
-        FROM mysql.user 
-        WHERE (plugin IN('mysql_native_password', 'mysql_old_password') 
-          AND LENGTH(password) = 0 AND LENGTH(authentication_string) = 0);
-    No rows will be returned if all accounts have a password set."
-
-    query = %{SELECT user,host FROM mysql.user WHERE (plugin IN('mysql_native_password', 'mysql_old_password') AND LENGTH(password) = 0 AND LENGTH(authentication_string) = 0);}
-    sql_session = mysql_session(attribute('user'), attribute('password'), attribute('host'), attribute('port'))
-    users_with_blank_passwords = sql_session.query(query).stdout.strip
-
-    describe 'The MySQL users with blank passwords' do
-      subject { users_with_blank_passwords }
-      it { should be_empty }
-    end
-  end
 
   control '7.6' do
     

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,7 +5,7 @@ copyright: The MITRE Corporation, 2018
 copyright_email: .
 summary: 'InSpec Validation Profile for AWS RDS Mysql server enterprise edition 5.7 CIS'
 license: Apache-2.0
-version: 1.0.9
+version: 1.0.10
 inspec_version: ">= 4.0"
 
 depends:


### PR DESCRIPTION
Fixes https://github.com/CMSgov/cms-ars-3.1-moderate-aws-rds-oracle-mysql-ee-5.7-cis-overlay/issues/6 

Reverting to original code of baseline. I had mistakenly adjusted this overlay by observing behavior in a 5.6 version of MySQL in RDS, thinking the differences were based on RDS. This was not the case. For this control, the behavior of MySQL 5.7 is the same when it is in RDS or Hosted.